### PR TITLE
Update to Rerun 0.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 # Rerun:
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://build.rerun.io/commit/e541a14/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.13.0/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 # VRS:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 # Rerun:
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://build.rerun.io/commit/71dde62/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://build.rerun.io/commit/e541a14/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 # VRS:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 # Rerun:
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.12.0/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://build.rerun.io/commit/71dde62/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 # VRS:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 # Rerun:
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.13.0/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://build.rerun.io/commit/693993d/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 # VRS:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 # Rerun:
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://build.rerun.io/commit/693993d/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.14.1/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 # VRS:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ If you choose not to use pixi, you will need to install a few things yourself be
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun Viewer are:
-* Via cargo: `cargo install rerun-cli@0.12.0`
-* Via pip: `pip install rerun-sdk==0.12.0`
+* Via cargo: `cargo install rerun-cli@0.13.0-rc.5`
+* Via pip: `pip install rerun-sdk==0.13.0-rc.5`
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ If you choose not to use pixi, you will need to install a few things yourself be
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun Viewer are:
-* Via cargo: `cargo install rerun-cli@0.13.0-rc.5`
-* Via pip: `pip install rerun-sdk==0.13.0-rc.5`
+* Via cargo: `cargo install rerun-cli@0.13.0-rc.7`
+* Via pip: `pip install rerun-sdk==0.13.0-rc.7`
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ You can download a sample `.vrs` file from <https://www.projectaria.com/datasets
   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/1200w.png">
 </picture>
 
+**:warning: Out-of-order logging :warning:**
+
+This example makes heavy use of out-of-order logging.
+
+The speedups added in Rerun 0.13 slow down ingestion speed for out of order logs.
+An update that makes the speedup work well in that case as well will come in the following release.
+An update that fixes this is planned for 0.13.1. Follow the progress [here](https://github.com/rerun-io/rerun/issues/4810).
+
 ## Compile and run using `pixi`
 The easiest way to get started is to install [pixi](https://prefix.dev/docs/pixi/overview).
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ If you choose not to use pixi, you will need to install a few things yourself be
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun Viewer are:
-* Via cargo: `cargo install rerun-cli@0.13.0-rc.7`
-* Via pip: `pip install rerun-sdk==0.13.0-rc.7`
+* Via cargo: `cargo install rerun-cli@0.13.0`
+* Via pip: `pip install rerun-sdk==0.13.0`
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ You can download a sample `.vrs` file from <https://www.projectaria.com/datasets
   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/cpp-example-vrs/c13ed42c13ecb65b0ef689533c0525ab97471e21/1200w.png">
 </picture>
 
-**:warning: Out-of-order logging :warning:**
-
-This example makes heavy use of out-of-order logging.
-
-The speedups added in Rerun 0.13 slow down ingestion speed for out of order logs.
-An update that makes the speedup work well in that case as well will come in the following release.
-An update that fixes this is planned for 0.13.1. Follow the progress [here](https://github.com/rerun-io/rerun/issues/4810).
 
 ## Compile and run using `pixi`
 The easiest way to get started is to install [pixi](https://prefix.dev/docs/pixi/overview).
@@ -60,6 +53,6 @@ We haven't tried getting this example working on Windows yet, because VRS has no
 
 
 ## Known limitations with Rerun
-* 0.10.0 of the Rerun C++ SDK accidentally shipped with parts of it compiled in Debug build, making it unnecessarily slow. This will be fixed in [Rerun 0.10.1](https://github.com/rerun-io/rerun/milestone/11).
-* Time-scalar plots are currently very slow in Rerun, something we're [actively working on](https://github.com/rerun-io/rerun/issues/374).
-* [Points cloud sizes are limited](https://github.com/rerun-io/rerun/issues/3076), and [big point clouds are slow](https://github.com/rerun-io/rerun/issues/1136).
+This example makes heavy use of out-of-order logging.
+This leads to slow ingestion speeds in Rerun, especially for plots.
+Follow the progress on this [here](https://github.com/rerun-io/rerun/issues/4810).

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ If you choose not to use pixi, you will need to install a few things yourself be
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun Viewer are:
-* Via cargo: `cargo install rerun-cli@0.13.0`
-* Via pip: `pip install rerun-sdk==0.13.0`
+* Via cargo: `cargo install rerun-cli@0.14.0-rc.4`
+* Via pip: `pip install rerun-sdk==0.14.0-rc.4`
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ If you choose not to use pixi, you will need to install a few things yourself be
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun Viewer are:
-* Via cargo: `cargo install rerun-cli@0.14.0-rc.4`
-* Via pip: `pip install rerun-sdk==0.14.0-rc.4`
+* Via cargo: `cargo install rerun-cli@0.14.1`
+* Via pip: `pip install rerun-sdk==0.14.1`
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 

--- a/src/imu_player.cpp
+++ b/src/imu_player.cpp
@@ -99,21 +99,21 @@ namespace rerun_vrs {
 
     void IMUPlayer::log_accelerometer(const std::array<float, 3>& accelMSec2) {
         _rec->log(_entity_path + "/accelerometer", rerun::Arrows3D::from_vectors({accelMSec2}));
-        _rec->log(_entity_path + "/accelerometer/x", rerun::TimeSeriesScalar(accelMSec2[0]));
-        _rec->log(_entity_path + "/accelerometer/y", rerun::TimeSeriesScalar(accelMSec2[1]));
-        _rec->log(_entity_path + "/accelerometer/z", rerun::TimeSeriesScalar(accelMSec2[2]));
+        _rec->log(_entity_path + "/accelerometer/x", rerun::Scalar(accelMSec2[0]));
+        _rec->log(_entity_path + "/accelerometer/y", rerun::Scalar(accelMSec2[1]));
+        _rec->log(_entity_path + "/accelerometer/z", rerun::Scalar(accelMSec2[2]));
     }
 
     void IMUPlayer::log_gyroscope(const std::array<float, 3>& gyroRadSec) {
-        _rec->log(_entity_path + "/gyroscope/x", rerun::TimeSeriesScalar(gyroRadSec[0]));
-        _rec->log(_entity_path + "/gyroscope/y", rerun::TimeSeriesScalar(gyroRadSec[1]));
-        _rec->log(_entity_path + "/gyroscope/z", rerun::TimeSeriesScalar(gyroRadSec[2]));
+        _rec->log(_entity_path + "/gyroscope/x", rerun::Scalar(gyroRadSec[0]));
+        _rec->log(_entity_path + "/gyroscope/y", rerun::Scalar(gyroRadSec[1]));
+        _rec->log(_entity_path + "/gyroscope/z", rerun::Scalar(gyroRadSec[2]));
     }
 
     void IMUPlayer::log_magnetometer(const std::array<float, 3>& magTesla) {
-        _rec->log(_entity_path + "/magnetometer/x", rerun::TimeSeriesScalar(magTesla[0]));
-        _rec->log(_entity_path + "/magnetometer/y", rerun::TimeSeriesScalar(magTesla[1]));
-        _rec->log(_entity_path + "/magnetometer/z", rerun::TimeSeriesScalar(magTesla[2]));
+        _rec->log(_entity_path + "/magnetometer/x", rerun::Scalar(magTesla[0]));
+        _rec->log(_entity_path + "/magnetometer/y", rerun::Scalar(magTesla[1]));
+        _rec->log(_entity_path + "/magnetometer/z", rerun::Scalar(magTesla[2]));
     }
 
     bool might_contain_imu_data(const vrs::StreamId& id) {


### PR DESCRIPTION
* Closes https://github.com/rerun-io/cpp-example-vrs/pull/7

Fixes the first-frame heuristics problems of 0.13